### PR TITLE
modify ownerList to track owners using bool

### DIFF
--- a/contracts/contracts/utils/OwnerList.sol
+++ b/contracts/contracts/utils/OwnerList.sol
@@ -15,5 +15,5 @@ pragma solidity ^0.8.0;
 // }
 struct OwnerList {
     uint256 count;
-    mapping(address => address) list;
+    mapping(address => bool) list;
 }

--- a/contracts/test/ProjectRegistry-test.ts
+++ b/contracts/test/ProjectRegistry-test.ts
@@ -10,7 +10,8 @@ const OWNERS_LIST_SENTINEL = "0x0000000000000000000000000000000000000001";
 
 describe("ProjectRegistry", function () {
   before(async function () {
-    [this.owner, this.projectRecipient, this.nonOwner, ...this.accounts] = await ethers.getSigners();
+    [this.owner, this.projectRecipient, this.nonOwner, ...this.accounts] =
+      await ethers.getSigners();
 
     const ProjectRegistry = await hre.ethers.getContractFactory(
       "ProjectRegistry",
@@ -23,36 +24,39 @@ describe("ProjectRegistry", function () {
   it("creates a new project and adds it to the projects list", async function () {
     expect(await this.contract.projectsCount()).to.equal("0");
 
-    await this.contract.createProject(
-      this.projectRecipient.address,
-      testMetadata
-    );
+    await this.contract.createProject(this.owner.address, testMetadata);
 
     expect(await this.contract.projectsCount()).to.equal("1");
 
     const project = await this.contract.projects(0);
     expect(project.id).to.equal("0");
-    expect(project.recipient).to.equal(this.projectRecipient.address);
+    expect(project.recipient).to.equal(this.owner.address);
 
     const [protocol, pointer] = project.metadata;
     expect(protocol).to.equal(testMetadata.protocol);
     expect(pointer).to.equal(testMetadata.pointer);
 
-    const owners = await this.contract.getProjectOwners(project.id);
-    expect(owners.length).to.equal(1);
-    expect(owners[0]).to.equal(this.owner.address);
+    const isProjectOwner = await this.contract.activeProjectOwner(
+      "0",
+      this.owner.address
+    );
+    expect(isProjectOwner).to.equal(true);
   });
 
   it("does not allow update of project metadata if not owner", async function () {
     const project = await this.contract.projects(0);
     await expect(
-      this.contract.connect(this.nonOwner).updateProjectMetaData(project.id, updatedMetadata)
+      this.contract
+        .connect(this.nonOwner)
+        .updateProjectMetaData(project.id, updatedMetadata)
     ).to.be.revertedWith("not owner");
   });
 
   it("updates project metadata", async function () {
     const project = await this.contract.projects(0);
-    await this.contract.updateProjectMetaData(project.id, updatedMetadata);
+    await this.contract
+      .connect(this.owner)
+      .updateProjectMetaData(project.id, updatedMetadata);
     const updatedProject = await this.contract.projects(0);
     const [protocol, pointer] = updatedProject.metadata;
     expect(protocol).to.equal(updatedMetadata.protocol);
@@ -61,9 +65,10 @@ describe("ProjectRegistry", function () {
 
   it("does not allow to add an owner if not owner", async function () {
     const projectID = 0;
-    const currentOwners = await this.contract.getProjectOwners(projectID);
     await expect(
-      this.contract.connect(this.nonOwner).addProjectOwner(projectID, this.nonOwner.address)
+      this.contract
+        .connect(this.nonOwner)
+        .addProjectOwner(projectID, this.nonOwner.address)
     ).to.be.revertedWith("not owner");
   });
 
@@ -71,92 +76,115 @@ describe("ProjectRegistry", function () {
     const projectID = 0;
 
     expect(await this.contract.projectOwnersCount(projectID)).to.equal("1");
-    const prevOwners = await this.contract.getProjectOwners(projectID);
-    expect(prevOwners.length).to.equal(1);
-    expect(prevOwners[0]).to.equal(this.owner.address);
+    expect(
+      await this.contract.activeProjectOwner(projectID, this.owner.address)
+    ).to.equal(true);
 
     for (let i = 0; i < 3; i++) {
-      await this.contract.connect(this.owner).addProjectOwner(projectID, this.accounts[i].address)
+      await this.contract
+        .connect(this.owner)
+        .addProjectOwner(projectID, this.accounts[i].address);
+      expect(
+        await this.contract.activeProjectOwner(
+          projectID,
+          this.accounts[i].address
+        )
+      ).to.equal(true);
     }
 
     expect(await this.contract.projectOwnersCount(projectID)).to.equal("4");
-    const owners = await this.contract.getProjectOwners(projectID);
-    expect(owners.length).to.equal(4);
-    expect(owners[0]).to.equal(this.accounts[2].address);
-    expect(owners[1]).to.equal(this.accounts[1].address);
-    expect(owners[2]).to.equal(this.accounts[0].address);
-    expect(owners[3]).to.equal(this.owner.address);
   });
 
   it("does not allow to remove an owner if not owner", async function () {
     const projectID = 0;
-    const currentOwners = await this.contract.getProjectOwners(projectID);
     await expect(
-      this.contract.connect(this.nonOwner).removeProjectOwner(projectID, this.owner.address, this.owner.address)
+      this.contract
+        .connect(this.nonOwner)
+        .removeProjectOwner(projectID, this.owner.address, this.owner.address)
     ).to.be.revertedWith("not owner");
   });
 
   it("does not allow to remove owner 0", async function () {
     const projectID = 0;
-    const currentOwners = await this.contract.getProjectOwners(projectID);
     await expect(
-      this.contract.connect(this.owner).removeProjectOwner(projectID, this.owner.address, ZERO_ADDRESS)
-    ).to.be.revertedWith("bad owner");
-  });
-
-  it("does not allow to remove owner equal to OWNERS_LIST_SENTINEL", async function () {
-    const projectID = 0;
-    const currentOwners = await this.contract.getProjectOwners(projectID);
-    await expect(
-      this.contract.connect(this.owner).removeProjectOwner(projectID, this.owner.address, OWNERS_LIST_SENTINEL)
+      this.contract
+        .connect(this.owner)
+        .removeProjectOwner(projectID, this.owner.address, ZERO_ADDRESS)
     ).to.be.revertedWith("bad owner");
   });
 
   it("does not allow to remove owner with bad prevOwner", async function () {
     const projectID = 0;
-    const currentOwners = await this.contract.getProjectOwners(projectID);
     await expect(
-      this.contract.connect(this.owner).removeProjectOwner(projectID, this.nonOwner.address, this.owner.address)
+      this.contract
+        .connect(this.owner)
+        .removeProjectOwner(
+          projectID,
+          this.nonOwner.address,
+          this.owner.address
+        )
     ).to.be.revertedWith("bad prevOwner");
   });
 
   it("removes owner", async function () {
     const projectID = 0;
-    const currentOwners = await this.contract.getProjectOwners(projectID);
 
     expect(await this.contract.projectOwnersCount(projectID)).to.equal("4");
-    const owners = await this.contract.getProjectOwners(projectID);
-    expect(owners.length).to.equal(4);
-    expect(currentOwners[0]).to.equal(this.accounts[2].address);
-    expect(currentOwners[1]).to.equal(this.accounts[1].address);
-    expect(currentOwners[2]).to.equal(this.accounts[0].address);
-    expect(currentOwners[3]).to.equal(this.owner.address);
+    for (let i = 0; i < 3; i++) {
+      expect(
+        await this.contract.activeProjectOwner(
+          projectID,
+          this.accounts[i].address
+        )
+      ).to.equal(true);
+    }
 
-    await this.contract.connect(this.owner).removeProjectOwner(projectID, this.accounts[1].address, this.accounts[0].address)
+    await this.contract
+      .connect(this.owner)
+      .removeProjectOwner(
+        projectID,
+        this.accounts[1].address,
+        this.accounts[0].address
+      );
     expect(await this.contract.projectOwnersCount(projectID)).to.equal("3");
-    let newOwners = await this.contract.getProjectOwners(projectID);
-    expect(newOwners.length).to.equal(3);
 
-    await this.contract.connect(this.owner).removeProjectOwner(projectID, this.accounts[1].address, this.owner.address)
+    await this.contract
+      .connect(this.owner)
+      .removeProjectOwner(
+        projectID,
+        this.accounts[1].address,
+        this.owner.address
+      );
     expect(await this.contract.projectOwnersCount(projectID)).to.equal("2");
-    newOwners = await this.contract.getProjectOwners(projectID);
-    expect(newOwners.length).to.equal(2);
 
-    await this.contract.connect(this.accounts[2]).removeProjectOwner(projectID, OWNERS_LIST_SENTINEL, this.accounts[2].address)
+    await this.contract
+      .connect(this.accounts[2])
+      .removeProjectOwner(
+        projectID,
+        this.accounts[2].address,
+        this.owner.address
+      );
     expect(await this.contract.projectOwnersCount(projectID)).to.equal("1");
-    newOwners = await this.contract.getProjectOwners(projectID);
-    expect(newOwners.length).to.equal(1);
-    expect(newOwners[0]).to.eq(this.accounts[1].address);
   });
 
   it("does not allow to remove owner if single owner", async function () {
     const projectID = 0;
     expect(await this.contract.projectOwnersCount(projectID)).to.equal("1");
-    const currentOwners = await this.contract.getProjectOwners(projectID);
-    expect(currentOwners[0]).to.eq(this.accounts[1].address);
+    expect(
+      await this.contract.activeProjectOwner(
+        projectID,
+        this.accounts[2].address
+      )
+    ).to.eq(true);
 
     await expect(
-      this.contract.connect(this.accounts[1]).removeProjectOwner(projectID, OWNERS_LIST_SENTINEL, this.accounts[1].address)
+      this.contract
+        .connect(this.accounts[1])
+        .removeProjectOwner(
+          projectID,
+          this.accounts[1].address,
+          this.accounts[2].address
+        )
     ).to.be.revertedWith("single owner");
   });
 });


### PR DESCRIPTION
This experiments with using a similar methodology as oppenzeppelin used to use implement permissions. Wanted to test it out . Could still be cleaned up 

This disadvantage is that I don't believe that you can fetch the entire list of owners, but you can check if in an individual owner is valid.

It does appear to reduce gas consumption

https://docs.openzeppelin.com/contracts/2.x/access-control#role-based-access-contro

bool:
<img width="856" alt="Screen Shot 2022-05-27 at 4 50 42 PM" src="https://user-images.githubusercontent.com/6887938/170797982-59483f90-c966-486b-a5dc-62d0ac4d969e.png">

linked list
<img width="859" alt="Screen Shot 2022-05-27 at 4 51 40 PM" src="https://user-images.githubusercontent.com/6887938/170798019-ea050f24-fe4f-42ef-8081-3f854871cdf1.png">

