### PR TITLE
Wagmi provider fix

### DIFF
--- a/client/src/components/grants/Landing.tsx
+++ b/client/src/components/grants/Landing.tsx
@@ -24,7 +24,7 @@ function Landing() {
 
   // dispatch initializeWeb3 when address changes
   useEffect(() => {
-    if (signer && provider && chain && address) {
+    if (signer && "getAddress" in signer && provider && chain && address) {
       dispatch(initializeWeb3(signer, provider, chain, address));
     }
   }, [signer, provider, chain, address]);


### PR DESCRIPTION
### Problem

In some cases ethers fails to call contracts because the provider passed doesn't have the `getAddress` method.

error in console: `TypeError: contract.signer.getAddress is not a function`

### How to reproduce

It's not always reproducible but it often happens doing the following on desktop:

* connectwith metamask
* disconnect
* connect with the rainbow wallet
* disconnet
* connect again with metamask

### Description

Following the steps above I can see that the signer is cached in localstorage, in the queries cached under the `wagmi.cache` key.

In these cases, calling `const { data: signer } = useSigner()` returns the first time the cached object, then null or undefined, and finally the actual `JsonRpcSigner`.

Since the first result is not null/undefined, we try to use the deserialized cached object that doesn't have the `getAddress` method and we have this error.

### Fix

With this PR we check that the object has the `getAddress` method to be sure it's an object instantiated and not the deserialized one.