### PR TITLE
Application signature

### DIFF
--- a/client/src/__tests__/utils/deterministicJSON.test.ts
+++ b/client/src/__tests__/utils/deterministicJSON.test.ts
@@ -1,4 +1,9 @@
-import { objectToSortedTuples, objectToDeterministicJSON, Obj, Tuple, Result } from "../../utils/deterministicJSON";
+import {
+  objectToSortedTuples,
+  objectToDeterministicJSON,
+  Obj,
+  Result,
+} from "../../utils/deterministicJSON";
 
 interface Scenarios {
   input: Obj;

--- a/client/src/__tests__/utils/deterministicJSON.test.ts
+++ b/client/src/__tests__/utils/deterministicJSON.test.ts
@@ -1,0 +1,71 @@
+import { objectToSortedTuples, objectToDeterministicJSON, Obj, Tuple, Result } from "../../utils/deterministicJSON";
+
+interface Scenarios {
+  input: Obj;
+  expected: Result;
+}
+
+describe("deterministicJSON", () => {
+  const scenarios: Scenarios[] = [
+    {
+      input: "foo",
+      expected: "foo",
+    },
+    {
+      input: 2,
+      expected: 2,
+    },
+    {
+      input: ["foo", 2],
+      expected: ["foo", 2],
+    },
+    {
+      input: { foo: "1", bar: 2 },
+      expected: [
+        ["foo", "1"],
+        ["bar", 2],
+      ],
+    },
+    {
+      input: {
+        foo: [2, 4, 6],
+      },
+      expected: [["foo", [2, 4, 6]]],
+    },
+    {
+      input: {
+        foo: {
+          bar: [2, 4, 6],
+        },
+      },
+      expected: [["foo", [["bar", [2, 4, 6]]]]],
+    },
+    {
+      input: {
+        foo: [{ bar: 2 }, { baz: 3 }],
+      },
+      expected: [["foo", [[["bar", 2]], [["baz", 3]]]]],
+    },
+    {
+      input: {
+        foo: [{ bar: 2 }, { baz: 3 }],
+        bar: undefined,
+      },
+      expected: [["foo", [[["bar", 2]], [["baz", 3]]]]],
+    },
+  ];
+
+  it("converts an object to a list of tuples", async () => {
+    scenarios.forEach((scenario) => {
+      const result: Result = objectToSortedTuples(scenario.input);
+      expect(result).toEqual(scenario.expected);
+    });
+  });
+
+  it("converts an object to a determinist JSON", async () => {
+    scenarios.forEach((scenario) => {
+      const result = objectToDeterministicJSON(scenario.input);
+      expect(result).toEqual(JSON.stringify(scenario.expected));
+    });
+  });
+});

--- a/client/src/__tests__/utils/deterministicJSON.test.ts
+++ b/client/src/__tests__/utils/deterministicJSON.test.ts
@@ -62,7 +62,7 @@ describe("deterministicJSON", () => {
     });
   });
 
-  it("converts an object to a determinist JSON", async () => {
+  it("converts an object to a deterministic JSON", async () => {
     scenarios.forEach((scenario) => {
       const result = objectToDeterministicJSON(scenario.input);
       expect(result).toEqual(JSON.stringify(scenario.expected));

--- a/client/src/reducers/roundApplication.ts
+++ b/client/src/reducers/roundApplication.ts
@@ -10,6 +10,7 @@ import {
 export const enum Status {
   Undefined = 0,
   BuildingApplication,
+  SigningApplication,
   UploadingMetadata,
   SendingTx,
   Sent,

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -162,6 +162,11 @@ export interface RoundApplication {
   }>;
 }
 
+export interface SignedRoundApplication {
+  signature: string;
+  application: RoundApplication;
+}
+
 export type ProviderID = "ClearTextTwitter" | "ClearTextGithubOrg";
 
 export type ProjectCredentials = {

--- a/client/src/utils/deterministicJSON.ts
+++ b/client/src/utils/deterministicJSON.ts
@@ -1,0 +1,35 @@
+export type Key = string | number;
+export type Obj = Key | { [key: string]: Obj } | Obj[] | undefined;
+
+export type Tuple = [Key, Key | Key[] | Tuple];
+export type Result = Key | Tuple | Result[] | undefined;
+
+export const objectToSortedTuples = (obj: Obj): Result => {
+  if (typeof obj === "string" || typeof obj === "number" || obj === undefined) {
+    return obj;
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map((i) => objectToSortedTuples(i));
+  }
+
+  const keys = Object.keys(obj);
+  const result: Result = [];
+
+  return keys.reduce((result, key) => {
+    const value = obj[key];
+
+    if (value === undefined) {
+      return result;
+    }
+
+    const sorted = objectToSortedTuples(value);
+    result.push([key, sorted] as Result);
+    return result;
+  }, result);
+};
+
+export const objectToDeterministicJSON = (obj: Obj): string => {
+  const tuples = objectToSortedTuples(obj);
+  return JSON.stringify(tuples);
+};

--- a/client/src/utils/deterministicJSON.ts
+++ b/client/src/utils/deterministicJSON.ts
@@ -14,19 +14,19 @@ export const objectToSortedTuples = (obj: Obj): Result => {
   }
 
   const keys = Object.keys(obj);
-  const result: Result = [];
+  const initialResult: Result = [];
 
-  return keys.reduce((result, key) => {
+  return keys.reduce((res, key) => {
     const value = obj[key];
 
     if (value === undefined) {
-      return result;
+      return res;
     }
 
     const sorted = objectToSortedTuples(value);
-    result.push([key, sorted] as Result);
-    return result;
-  }, result);
+    res.push([key, sorted] as Result);
+    return res;
+  }, initialResult);
 };
 
 export const objectToDeterministicJSON = (obj: Obj): string => {

--- a/client/src/utils/roundApplication.ts
+++ b/client/src/utils/roundApplication.ts
@@ -12,6 +12,4 @@ const generateUniqueRoundApplicationID = (
   );
 };
 
-export default {
-  generateUniqueRoundApplicationID,
-};
+export default generateUniqueRoundApplicationID;


### PR DESCRIPTION
This PR enables the signature of the round application data sent to the round manager. 
The round application type is still the same, but the file uploaded to IPFS becomes:

```
export interface SignedRoundApplication {
  signature: string;
  application: RoundApplication;
}
```

`signature` is the actual signature of the round application, created using `ethers.signMessage(hash)`

`hash` is the keccak256 of the deterministic JSON of the application. 

The deterministic JSON is created with the `objectToDeterministicJSON` function included in this PR.
This allows us to have a deterministic string to hash, since the JSON implementation of an object doesn't ensure the order of its keys.

The `hash` hex string is created using `ethers.utils.solidityKeccak256`.

closes #253 
