### PR TITLE
Fix project form infinite loop

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -57,7 +57,7 @@
     "start": "craco start",
     "build": "export REACT_APP_GIT_SHA=$(git rev-parse --short HEAD); env REACT_APP_GIT_SHA=${REACT_APP_GIT_SHA:-$CF_PAGES_COMMIT_SHA} craco build",
     "test": "jest --watchAll=false",
-    "test:dev": "jest --watch=true",
+    "test:dev": "jest --watch",
     "test:coverage": "jest --watchAll=false --coverage",
     "eject": "react-scripts eject",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx ./src --cache",

--- a/client/src/actions/newGrant.ts
+++ b/client/src/actions/newGrant.ts
@@ -6,6 +6,7 @@ import { RootState } from "../reducers";
 import ProjectRegistryABI from "../contracts/abis/ProjectRegistry.json";
 import { addressesByChainID } from "../contracts/deployments";
 import { NewGrant, Status } from "../reducers/newGrant";
+import { fetchGrantData } from "./grantsMetadata";
 import PinataClient from "../services/pinata";
 
 export const NEW_GRANT_STATUS = "NEW_GRANT_STATUS";
@@ -126,5 +127,8 @@ export const publishGrant =
     const txStatus = await projectTx.wait();
     if (txStatus.status) {
       dispatch(grantStatus(Status.Completed, undefined));
+      if (grantId !== undefined) {
+        dispatch<any>(fetchGrantData(Number(grantId)));
+      }
     }
   };

--- a/client/src/actions/projectForm.ts
+++ b/client/src/actions/projectForm.ts
@@ -1,14 +1,23 @@
 import { FormInputs, ProjectCredentials } from "../types";
 
 export const METADATA_SAVED = "METADATA_SAVED";
+export const METADATA_IMAGE_SAVED = "METADATA_IMAGE_SAVED";
 export const CREDENTIALS_SAVED = "CREDENTIALS_SAVED";
 export const FORM_RESET = "FORM_RESET";
+
 export interface FormReset {
   type: typeof FORM_RESET;
 }
+
 export interface MetadataSaved {
   type: typeof METADATA_SAVED;
   metadata: FormInputs;
+}
+
+export interface MetadataImageSaved {
+  type: typeof METADATA_IMAGE_SAVED;
+  image?: Blob;
+  fieldName: string;
 }
 
 export interface CredentialsSaved {
@@ -16,7 +25,7 @@ export interface CredentialsSaved {
   credentials?: ProjectCredentials;
 }
 
-export type ProjectFormActions = MetadataSaved | CredentialsSaved | FormReset;
+export type ProjectFormActions = MetadataSaved | MetadataImageSaved | CredentialsSaved | FormReset;
 
 export const formReset = (): ProjectFormActions => ({
   type: FORM_RESET,
@@ -26,8 +35,6 @@ export const metadataSaved = ({
   title,
   description,
   website,
-  bannerImg,
-  logoImg,
   projectTwitter,
   userGithub,
   projectGithub,
@@ -37,12 +44,16 @@ export const metadataSaved = ({
     title,
     description,
     website,
-    bannerImg,
-    logoImg,
     projectTwitter,
     userGithub,
     projectGithub,
   },
+});
+
+export const metadataImageSaved = (image: Blob | undefined, fieldName: string) => ({
+  type: METADATA_IMAGE_SAVED,
+  image,
+  fieldName
 });
 
 export const credentialsSaved = ({

--- a/client/src/actions/projectForm.ts
+++ b/client/src/actions/projectForm.ts
@@ -25,7 +25,11 @@ export interface CredentialsSaved {
   credentials?: ProjectCredentials;
 }
 
-export type ProjectFormActions = MetadataSaved | MetadataImageSaved | CredentialsSaved | FormReset;
+export type ProjectFormActions =
+  | MetadataSaved
+  | MetadataImageSaved
+  | CredentialsSaved
+  | FormReset;
 
 export const formReset = (): ProjectFormActions => ({
   type: FORM_RESET,
@@ -50,10 +54,13 @@ export const metadataSaved = ({
   },
 });
 
-export const metadataImageSaved = (image: Blob | undefined, fieldName: string) => ({
+export const metadataImageSaved = (
+  image: Blob | undefined,
+  fieldName: string
+) => ({
   type: METADATA_IMAGE_SAVED,
   image,
-  fieldName
+  fieldName,
 });
 
 export const credentialsSaved = ({

--- a/client/src/components/base/ImageInput.tsx
+++ b/client/src/components/base/ImageInput.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { useRef, useState } from "react";
 import PinataClient from "../../services/pinata";
 import colors from "../../styles/colors";
@@ -90,7 +91,7 @@ export default function ImageInput({
     imgHandler(blob);
   };
 
-  const currentImg = () => {
+  const loadCurrentImg = (existingImg?: string) => {
     if (!existingImg) return "";
 
     // Fetch existing img path from Pinata for display
@@ -106,6 +107,13 @@ export default function ImageInput({
       fileInput.current.click();
     }
   };
+
+  const [currentImg, setCurrentImg] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    const i = loadCurrentImg(existingImg);
+    setCurrentImg(i);
+  }, [existingImg]);
 
   return (
     <>
@@ -149,10 +157,10 @@ export default function ImageInput({
                 alt="Project Logo Preview"
               />
             )}
-            {currentImg() && canvas === undefined && (
+            {currentImg !== undefined && currentImg !== "" && canvas === undefined && (
               <img
                 className={`max-h-28 ${circle && "rounded-full"}`}
-                src={currentImg()}
+                src={currentImg}
                 alt="Project Logo Preview"
               />
             )}

--- a/client/src/components/base/ImageInput.tsx
+++ b/client/src/components/base/ImageInput.tsx
@@ -1,5 +1,4 @@
-import { useEffect } from "react";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import PinataClient from "../../services/pinata";
 import colors from "../../styles/colors";
 import CloudUpload from "../icons/CloudUpload";
@@ -91,12 +90,12 @@ export default function ImageInput({
     imgHandler(blob);
   };
 
-  const loadCurrentImg = (existingImg?: string) => {
-    if (!existingImg) return "";
+  const loadCurrentImg = (image?: string) => {
+    if (!image) return "";
 
     // Fetch existing img path from Pinata for display
     const pinataClient = new PinataClient();
-    const imgUrl = pinataClient.fileURL(existingImg);
+    const imgUrl = pinataClient.fileURL(image);
 
     blobExistingImg(imgUrl);
     return imgUrl;
@@ -157,13 +156,15 @@ export default function ImageInput({
                 alt="Project Logo Preview"
               />
             )}
-            {currentImg !== undefined && currentImg !== "" && canvas === undefined && (
-              <img
-                className={`max-h-28 ${circle && "rounded-full"}`}
-                src={currentImg}
-                alt="Project Logo Preview"
-              />
-            )}
+            {currentImg !== undefined &&
+              currentImg !== "" &&
+              canvas === undefined && (
+                <img
+                  className={`max-h-28 ${circle && "rounded-full"}`}
+                  src={currentImg}
+                  alt="Project Logo Preview"
+                />
+              )}
           </div>
         </div>
       </div>

--- a/client/src/components/base/ProjectForm.tsx
+++ b/client/src/components/base/ProjectForm.tsx
@@ -79,12 +79,12 @@ function ProjectForm({
   const logoChangedHandler = (logo?: Blob) => {
     setLogoImg(logo);
     dispatch(metadataImageSaved(logo, "logoImg"));
-  }
+  };
 
   const bannerChangedHandler = (banner?: Blob) => {
     setBannerImg(banner);
     dispatch(metadataImageSaved(banner, "bannerImg"));
-  }
+  };
 
   const validate = async () => {
     try {

--- a/client/src/components/base/ProjectForm.tsx
+++ b/client/src/components/base/ProjectForm.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { shallowEqual, useDispatch, useSelector } from "react-redux";
 import { ValidationError } from "yup";
 import { fetchGrantData } from "../../actions/grantsMetadata";
-import { metadataSaved } from "../../actions/projectForm";
+import { metadataSaved, metadataImageSaved } from "../../actions/projectForm";
 import { RootState } from "../../reducers";
 import { Status } from "../../reducers/grantsMetadata";
 import { ChangeHandlers, FormInputs, ProjectFormStatus } from "../../types";
@@ -76,6 +76,16 @@ function ProjectForm({
     }
   }, [dispatch, currentProjectId, props.currentProject]);
 
+  const logoChangedHandler = (logo?: Blob) => {
+    setLogoImg(logo);
+    dispatch(metadataImageSaved(logo, "logoImg"));
+  }
+
+  const bannerChangedHandler = (banner?: Blob) => {
+    setBannerImg(banner);
+    dispatch(metadataImageSaved(banner, "bannerImg"));
+  }
+
   const validate = async () => {
     try {
       await validateProjectForm(props.formMetaData);
@@ -141,7 +151,7 @@ function ProjectForm({
           }}
           circle
           existingImg={props.currentProject?.logoImg}
-          imgHandler={(buffer: Blob) => setLogoImg(buffer)}
+          imgHandler={(buffer: Blob) => logoChangedHandler(buffer)}
         />
         <ImageInput
           label="Project Banner"
@@ -150,7 +160,7 @@ function ProjectForm({
             height: 500,
           }}
           existingImg={props.currentProject?.bannerImg}
-          imgHandler={(buffer: Blob) => setBannerImg(buffer)}
+          imgHandler={(buffer: Blob) => bannerChangedHandler(buffer)}
         />
         <TextInput
           label="Project Twitter"

--- a/client/src/reducers/projectForm.ts
+++ b/client/src/reducers/projectForm.ts
@@ -28,7 +28,7 @@ export const projectFormReducer = (
         metadata: {
           ...state.metadata,
           ...action.metadata,
-        }
+        },
       };
     }
 
@@ -38,7 +38,7 @@ export const projectFormReducer = (
         metadata: {
           ...state.metadata,
           [action.fieldName]: action.image,
-        }
+        },
       };
     }
 

--- a/client/src/reducers/projectForm.ts
+++ b/client/src/reducers/projectForm.ts
@@ -1,5 +1,6 @@
 import {
   METADATA_SAVED,
+  METADATA_IMAGE_SAVED,
   CREDENTIALS_SAVED,
   FORM_RESET,
   ProjectFormActions,
@@ -24,15 +25,30 @@ export const projectFormReducer = (
     case METADATA_SAVED: {
       return {
         ...state,
-        metadata: action.metadata,
+        metadata: {
+          ...state.metadata,
+          ...action.metadata,
+        }
       };
     }
+
+    case METADATA_IMAGE_SAVED: {
+      return {
+        ...state,
+        metadata: {
+          ...state.metadata,
+          [action.fieldName]: action.image,
+        }
+      };
+    }
+
     case CREDENTIALS_SAVED: {
       return {
         ...state,
         credentials: action.credentials,
       };
     }
+
     case FORM_RESET: {
       return initialState;
     }


### PR DESCRIPTION
### Problem 1 

In the current version testable in staging when editing a project, the input image component causes an infinite loop when it loads the image blob and sends it to the parent handlers.

**Solution**

We fix it loading the image once using useEffect, and dispatching two different actions, one for the images, and one for the reset of the metadata fields.

### Problem 2

If I try to publish a project without editing the form, banner and logo are the ipfs hashes instead of blobs, so publishing to pinata fails, and it's not possible to publish the project.

**Solution**

We now load the image blobs when the form renders.

### Problem 3

When I updated a project and I'm redirected to the dashboard, I still see the old project metadata until I refresh the page.

**Solution**

We fetch the project metadata after updating it.
