### PR TITLE
Format date and change order of fields in project details

### DIFF
--- a/client/src/components/grants/Details.tsx
+++ b/client/src/components/grants/Details.tsx
@@ -105,7 +105,7 @@ export default function Details({
         {project?.projectGithub && (
           <div className="flex justify-start items-center">
             <img
-              className="h-3 mr-2 mt-1"
+              className="h-4 mr-2 mt-1"
               src="./assets/github_logo.png"
               alt="Github Logo"
             />
@@ -123,7 +123,7 @@ export default function Details({
         {project?.projectGithub && (
           <div className="flex justify-start items-center">
             <img
-              className="h-3 mr-2 mt-1"
+              className="h-4 mr-2 mt-1"
               src="./assets/github_logo.png"
               alt="Github Logo"
             />

--- a/client/src/components/grants/Details.tsx
+++ b/client/src/components/grants/Details.tsx
@@ -61,24 +61,20 @@ export default function Details({
       <h4 className="mb-4 mt-14">{project?.title}</h4>
       <div className="grid grid-cols-2 gap-4 pb-6 mb-6">
         <div>
-          <p className="flex text-sm">
-            <Calendar color={colors["secondary-text"]} />
-            <span className="ml-1">Created: {createdAt}</span>
-          </p>
+          <a
+            target="_blank"
+            href={project?.website}
+            className="flex items-center mr-6 text-primary-background"
+            rel="noreferrer"
+          >
+            <LinkIcon color={colors["secondary-text"]} />{" "}
+            <span className="ml-1">{project?.website}</span>
+          </a>
         </div>
-        <a
-          target="_blank"
-          href={project?.website}
-          className="flex items-center mr-6 text-primary-background"
-          rel="noreferrer"
-        >
-          <LinkIcon color={colors["secondary-text"]} />{" "}
-          <span className="ml-1">{project?.website}</span>
-        </a>
         <div>
           <p className="flex text-sm">
             <Calendar color={colors["secondary-text"]} />
-            <span className="ml-1">Last Edited: {updatedAt}</span>
+            <span className="ml-1">Created on: {createdAt}</span>
           </p>
         </div>
         {project?.projectTwitter && (
@@ -99,6 +95,13 @@ export default function Details({
             {project?.credentials?.twitter && <Verified />}
           </div>
         )}
+
+        <div>
+          <p className="flex text-sm">
+            <Calendar color={colors["secondary-text"]} />
+            <span className="ml-1">Last Edited: {updatedAt}</span>
+          </p>
+        </div>
         {project?.projectGithub && (
           <div className="flex justify-start items-center">
             <img

--- a/client/src/components/grants/Show.tsx
+++ b/client/src/components/grants/Show.tsx
@@ -76,7 +76,7 @@ function Project() {
             (updatedBlockData?.timestamp ?? 0) * 1000
           ).toLocaleString("en", {
             year: "numeric",
-            month: "short",
+            month: "long",
             day: "numeric",
           });
 
@@ -84,7 +84,7 @@ function Project() {
             (createdBlockData?.timestamp ?? 0) * 1000
           ).toLocaleString("en", {
             year: "numeric",
-            month: "short",
+            month: "long",
             day: "numeric",
           });
 

--- a/client/src/components/grants/Show.tsx
+++ b/client/src/components/grants/Show.tsx
@@ -74,11 +74,19 @@ function Project() {
 
           const formattedUpdatedAtDate = new Date(
             (updatedBlockData?.timestamp ?? 0) * 1000
-          ).toLocaleString();
+          ).toLocaleString("en", {
+            year: "numeric",
+            month: "short",
+            day: "numeric",
+          });
 
           const formattedCreatedAtDate = new Date(
             (createdBlockData?.timestamp ?? 0) * 1000
-          ).toLocaleString();
+          ).toLocaleString("en", {
+            year: "numeric",
+            month: "short",
+            day: "numeric",
+          });
 
           setUpdatedAt(formattedUpdatedAtDate);
           setCreatedAt(formattedCreatedAtDate);


### PR DESCRIPTION
This addresses #300 

Note that using `toLocaleString` there doesn't seem to be a way to get they days as e.g. "1st", "2nd" but only as "1", "2" etc.

If we want that we might have to write our own date formatting, unless I am missing something. Documentation is [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleString).