### PR TITLE
Project form fix

### DIFF
--- a/client/.eslint.js
+++ b/client/.eslint.js
@@ -1,0 +1,38 @@
+module.exports = {
+  env: {
+    browser: true,
+    es2021: true,
+  },
+  parser: "@typescript-eslint/parser",
+  extends: ["airbnb", "airbnb-typescript", "prettier"],
+  parserOptions: {
+    project: "./tsconfig.json",
+    ecmaVersion: 12,
+    sourceType: "module",
+    tsx: true
+  },
+  plugins: ["react", "prettier"],
+  rules: {
+    "prettier/prettier": "error",
+    "react/react-in-jsx-scope": "off",
+    "default-case": "off",
+    "max-classes-per-file": "off",
+    "class-methods-use-this": "off",
+    "@typescript-eslint/default-param-last": "off",
+    "import/no-cycle": "off",
+    "import/no-extraneous-dependencies": "off",
+    "react/prop-types": "off",
+    "max-len": ["error", { "code": 150 }],
+    "no-console": "off",
+    "no-restricted-syntax": [
+      "error",
+      "ForInStatement",
+      // "ForOfStatement", // used for async iterators
+      "LabeledStatement",
+      "WithStatement",
+    ],
+    "eol-last": ["error", "always"],
+    "react/require-default-props": "off"
+  },
+  ignorePatterns: ["node_modules/"],
+};

--- a/client/src/actions/newGrant.ts
+++ b/client/src/actions/newGrant.ts
@@ -71,13 +71,13 @@ export const publishGrant =
 
     const pinataClient = new PinataClient();
     dispatch(grantStatus(Status.UploadingImages, undefined));
-    if (formMetaData?.bannerImg) {
-      const resp = await pinataClient.pinFile(formMetaData.bannerImg);
+    if (formMetaData?.bannerImgData !== undefined) {
+      const resp = await pinataClient.pinFile(formMetaData.bannerImgData);
       application.bannerImg = resp.IpfsHash;
     }
 
-    if (formMetaData?.logoImg) {
-      const resp = await pinataClient.pinFile(formMetaData.logoImg);
+    if (formMetaData?.logoImgData !== undefined) {
+      const resp = await pinataClient.pinFile(formMetaData.logoImgData);
       application.logoImg = resp.IpfsHash;
     }
 

--- a/client/src/actions/projectForm.ts
+++ b/client/src/actions/projectForm.ts
@@ -42,6 +42,8 @@ export const metadataSaved = ({
   projectTwitter,
   userGithub,
   projectGithub,
+  logoImg,
+  bannerImg,
 }: FormInputs): ProjectFormActions => ({
   type: METADATA_SAVED,
   metadata: {
@@ -51,11 +53,13 @@ export const metadataSaved = ({
     projectTwitter,
     userGithub,
     projectGithub,
+    logoImg,
+    bannerImg,
   },
 });
 
 export const metadataImageSaved = (
-  image: Blob | undefined,
+  image: Blob | string | undefined,
   fieldName: string
 ) => ({
   type: METADATA_IMAGE_SAVED,

--- a/client/src/components/base/ImageInput.tsx
+++ b/client/src/components/base/ImageInput.tsx
@@ -32,7 +32,6 @@ export default function ImageInput({
   const fileInput = useRef<HTMLInputElement>(null);
   const [imgSrc, setImgSrc] = useState<string | undefined>();
   const [showCrop, setShowCrop] = useState(false);
-  const [canvas, setCanvas] = useState<HTMLCanvasElement | undefined>();
   const [validation, setValidation] = useState({
     error: false,
     msg: "",
@@ -113,22 +112,19 @@ export default function ImageInput({
     }
   };
 
-  const [currentImg, setCurrentImg] = useState<string | undefined>(undefined);
-
   useEffect(() => {
     if (imageData === undefined && imageHash !== undefined) {
-      const i = loadCurrentImg(imageHash);
-      setCurrentImg(i);
+      loadCurrentImg(imageHash);
     }
-  });
+  }, [imageData, imageHash]);
 
   useEffect(() => {
     if (imageData !== undefined) {
       const fr = new FileReader();
       fr.onload = () => {
         setImgSrc(fr.result as string);
-      }
-      fr.readAsDataURL(imageData)
+      };
+      fr.readAsDataURL(imageData);
     } else {
       setImgSrc(undefined);
     }
@@ -169,11 +165,13 @@ export default function ImageInput({
             </button>
           )}
           <div className="w-1/3">
-            {imgSrc && <><img
-              className={`max-h-28 ${circle && "rounded-full"}`}
-              src={imgSrc}
-              alt="Project Logo Preview"
-          /></>}
+            {imgSrc && (
+              <img
+                className={`max-h-28 ${circle && "rounded-full"}`}
+                src={imgSrc}
+                alt="Project Logo Preview"
+              />
+            )}
           </div>
         </div>
       </div>
@@ -198,7 +196,6 @@ export default function ImageInput({
         dimensions={dimensions}
         onClose={() => setShowCrop(false)}
         saveCrop={(imgUrl) => {
-          setCanvas(imgUrl);
           imgUrl.toBlob((blob) => blob && imgHandler(blob));
         }}
       />

--- a/client/src/components/base/Preview.tsx
+++ b/client/src/components/base/Preview.tsx
@@ -72,9 +72,9 @@ export default function Preview({
         updatedAt={formatDate(Date.now() / 1000)}
         createdAt={formatDate(Date.now() / 1000)}
         project={project}
-        logoImg={props.metadata?.logoImg ?? "./assets/default-project-logo.png"}
+        logoImg={props.metadata?.logoImgData ?? "./assets/default-project-logo.png"}
         bannerImg={
-          props.metadata?.bannerImg ?? "./assets/default-project-banner.png"
+          props.metadata?.bannerImgData ?? "./assets/default-project-banner.png"
         }
       />
       <div className="flex justify-end">

--- a/client/src/components/base/Preview.tsx
+++ b/client/src/components/base/Preview.tsx
@@ -72,7 +72,9 @@ export default function Preview({
         updatedAt={formatDate(Date.now() / 1000)}
         createdAt={formatDate(Date.now() / 1000)}
         project={project}
-        logoImg={props.metadata?.logoImgData ?? "./assets/default-project-logo.png"}
+        logoImg={
+          props.metadata?.logoImgData ?? "./assets/default-project-logo.png"
+        }
         bannerImg={
           props.metadata?.bannerImgData ?? "./assets/default-project-banner.png"
         }

--- a/client/src/components/base/ProjectForm.tsx
+++ b/client/src/components/base/ProjectForm.tsx
@@ -1,15 +1,9 @@
 import { useEffect, useState } from "react";
 import { shallowEqual, useDispatch, useSelector } from "react-redux";
 import { ValidationError } from "yup";
-import { fetchGrantData } from "../../actions/grantsMetadata";
 import { metadataSaved, metadataImageSaved } from "../../actions/projectForm";
 import { RootState } from "../../reducers";
-import {
-  ChangeHandlers,
-  // FormInputs,
-  ProjectFormStatus,
-  Metadata,
-} from "../../types";
+import { ChangeHandlers, ProjectFormStatus } from "../../types";
 import { TextArea, TextInput, WebsiteInput } from "../grants/inputs";
 import Button, { ButtonVariants } from "./Button";
 import ExitModal from "./ExitModal";
@@ -23,10 +17,8 @@ const validation = {
 };
 
 function ProjectForm({
-  projectID,
   setVerifying,
 }: {
-  projectID?: string;
   setVerifying: (verifying: ProjectFormStatus) => void;
 }) {
   const dispatch = useDispatch();
@@ -44,8 +36,8 @@ function ProjectForm({
   const [submitted, setSubmitted] = useState(false);
   const [modalOpen, toggleModal] = useState(false);
 
-  const [logoImg, setLogoImg] = useState<Blob | undefined>();
-  const [bannerImg, setBannerImg] = useState<Blob | undefined>();
+  const [, setLogoImg] = useState<Blob | undefined>();
+  const [, setBannerImg] = useState<Blob | undefined>();
 
   const handleInput = (e: ChangeHandlers) => {
     const { value } = e.target;

--- a/client/src/components/grants/Edit.tsx
+++ b/client/src/components/grants/Edit.tsx
@@ -12,7 +12,7 @@ import ExitModal from "../base/ExitModal";
 import VerificationForm from "../base/VerificationForm";
 import { ProjectFormStatus } from "../../types";
 import Preview from "../base/Preview";
-import { metadataSaved, metadataImageSaved, credentialsSaved} from "../../actions/projectForm";
+import { metadataSaved, credentialsSaved } from "../../actions/projectForm";
 
 function EditProject() {
   const params = useParams();
@@ -81,7 +81,6 @@ function EditProject() {
         return (
           <ProjectForm
             setVerifying={(verifyUpdate) => setFormStatus(verifyUpdate)}
-            projectID={projectID}
           />
         );
       case ProjectFormStatus.Verification:

--- a/client/src/components/grants/New.tsx
+++ b/client/src/components/grants/New.tsx
@@ -35,11 +35,7 @@ function NewProject() {
           />
         );
       default:
-        return (
-          <ProjectForm
-            setVerifying={(verifyUpdate) => setFormStatus(verifyUpdate)}
-          />
-        );
+        return null;
     }
   };
 

--- a/client/src/components/grants/Toggle.tsx
+++ b/client/src/components/grants/Toggle.tsx
@@ -6,7 +6,7 @@ import {
   AccordionPanel,
   Box,
 } from "@chakra-ui/react";
-import { FormInputs, Metadata, Project } from "../../types";
+import { Metadata, Project } from "../../types";
 import ToggleDetails from "./ToggleDetails";
 
 export default function Toggle({

--- a/client/src/components/grants/Toggle.tsx
+++ b/client/src/components/grants/Toggle.tsx
@@ -13,7 +13,7 @@ export default function Toggle({
   projectMetadata,
   showProjectDetails,
 }: {
-  projectMetadata?: Metadata | FormInputs | Project;
+  projectMetadata?: Metadata | Project;
   showProjectDetails: boolean;
 }) {
   return (

--- a/client/src/components/grants/ToggleDetails.tsx
+++ b/client/src/components/grants/ToggleDetails.tsx
@@ -1,4 +1,5 @@
 import { FormInputs, Metadata, Project } from "../../types";
+import { getProjectImage, ImgTypes } from "../../utils/components";
 
 function Section({ title, text }: { title: string; text: string | undefined }) {
   return (
@@ -20,7 +21,7 @@ function Section({ title, text }: { title: string; text: string | undefined }) {
 export default function ToggleDetails({
   project,
 }: {
-  project?: Metadata | FormInputs | Project;
+  project?: Metadata | Project;
 }) {
   return (
     <div className="w-full h-full">
@@ -37,11 +38,7 @@ export default function ToggleDetails({
         </div>
         <img
           className="w-full mb-4"
-          src={
-            project?.bannerImg instanceof Blob
-              ? URL.createObjectURL(project?.bannerImg)
-              : "./assets/default-project-banner.png"
-          }
+          src={getProjectImage(false, ImgTypes.bannerImg, project)}
           onError={(e) => {
             e.currentTarget.onerror = null;
             e.currentTarget.src = "./assets/default-project-banner.png";
@@ -56,11 +53,7 @@ export default function ToggleDetails({
         <div className="rounded-full h-20 w-20 bg-quaternary-text border border-tertiary-text flex justify-center items-center">
           <img
             className="rounded-full"
-            src={
-              project?.logoImg instanceof Blob
-                ? URL.createObjectURL(project?.logoImg)
-                : "./assets/default-project-logo.png"
-            }
+            src={getProjectImage(false, ImgTypes.logoImg, project)}
             onError={(e) => {
               e.currentTarget.onerror = null;
               e.currentTarget.src = "./assets/default-project-logo.png";

--- a/client/src/components/grants/ToggleDetails.tsx
+++ b/client/src/components/grants/ToggleDetails.tsx
@@ -1,4 +1,4 @@
-import { FormInputs, Metadata, Project } from "../../types";
+import { Metadata, Project } from "../../types";
 import { getProjectImage, ImgTypes } from "../../utils/components";
 
 function Section({ title, text }: { title: string; text: string | undefined }) {

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -14,9 +14,9 @@ export interface Metadata {
   website: string;
   bannerImg?: string;
   logoImg?: string;
+  projectTwitter?: string;
   userGithub?: string;
   projectGithub?: string;
-  projectTwitter?: string;
   credentials?: ProjectCredentials;
 }
 
@@ -175,11 +175,13 @@ export type FormInputs = {
   title?: string;
   description?: string;
   website?: string;
+  bannerImg?: string;
+  bannerImgData?: Blob;
+  logoImg?: string;
+  logoImgData?: Blob;
   projectTwitter?: string;
   userGithub?: string;
   projectGithub?: string;
-  bannerImg?: Blob;
-  logoImg?: Blob;
   credentials?: ProjectCredentials;
 };
 

--- a/client/src/utils/utils.ts
+++ b/client/src/utils/utils.ts
@@ -40,5 +40,3 @@ export const metadataToProject = (
 
   return p;
 };
-
-export {};


### PR DESCRIPTION
# Problem

The project creation is divided in multiple steps, starting with the project form.
When editing a project, if a user goes to the second step and back to the first one, all changes are lost.

# Solution

The project form state is managed in the project form component, but the full edit process is under the Edit component.
The Edit component renders a different child depending on the step, and when it renders the project forms it re-initialize it with the original project metadata.

With this PR we move the form state management up to the Edit component to avoid resetting it when going back to the project form.

# Tests

Tests are in another WIP PR https://github.com/gitcoinco/grant-hub/pull/410, we need to fix a compile error when importing `ReactCrop`.
