### PR TITLE
update fantom mainnet rpc url

### DIFF
--- a/client/src/utils/wagmi.ts
+++ b/client/src/utils/wagmi.ts
@@ -49,7 +49,7 @@ const fantomMainnet: Chain = {
     symbol: "FTM",
   },
   rpcUrls: {
-    default: "https://rpc.ankr.com/fantom/",
+    default: "https://rpc.ftm.tools/",
   },
   blockExplorers: {
     default: { name: "ftmscan", url: "https://ftmscan.com" },


### PR DESCRIPTION
With the previous RPC URL we had range limits on events queries and we could only fetch events in the last 100 blocks.

closes #509 

