### PR TITLE
Redeployed subgraphs under "gitcoinco" org

### DIFF
--- a/graph/README.md
+++ b/graph/README.md
@@ -11,13 +11,12 @@ This package holds the subgraph which indexs data with regard the
 
 The following sections document the hosted services where the subgraph is deployed across different networks
 
-| Network        | GITHUB_USER/SUBGRAPH_NAME                      | Playground                                                                                  | Query                                                                                  |
-| -------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| optimism       | danielesalatti/grant-hub-project-registry      | https://thegraph.com/hosted-service/subgraph/danielesalatti/grant-hub-project-registry      | https://api.thegraph.com/subgraphs/name/danielesalatti/grant-hub-project-registry      |
-| goerli         | danielesalatti/project-registry-goerli         | https://thegraph.com/hosted-service/subgraph/danielesalatti/project-registry-goerli         | https://api.thegraph.com/subgraphs/name/danielesalatti/project-registry-goerli         |
-| optimism-kovan | danielesalatti/project-registry-optimism-kovan | https://thegraph.com/hosted-service/subgraph/danielesalatti/project-registry-optimism-kovan | https://api.thegraph.com/subgraphs/name/danielesalatti/project-registry-optimism-kovan |
-| fantom         | danielesalatti/grantshub-project-registry-ftm  | https://thegraph.com/hosted-service/subgraph/danielesalatti/grantshub-project-registry-ftm  | https://api.thegraph.com/subgraphs/name/danielesalatti/grantshub-project-registry-ftm  |
-| fantom-testnet | danielesalatti/grantshub-project-registry-ftt  | https://thegraph.com/hosted-service/subgraph/danielesalatti/grantshub-project-registry-ftt  | https://api.thegraph.com/subgraphs/name/danielesalatti/grantshub-project-registry-ftt  |
+| Network        | GITHUB_USER/SUBGRAPH_NAME             | Playground                                                                         | Query                                                                         |
+| -------------- | ------------------------------------- | ---------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| optimism       | gitcoinco/grants-hub-optimism-mainnet | https://thegraph.com/hosted-service/subgraph/gitcoinco/grants-hub-optimism-mainnet | https://api.thegraph.com/subgraphs/name/gitcoinco/grants-hub-optimism-mainnet |
+| goerli         | gitcoinco/grants-hub-goerli-testnet   | https://thegraph.com/hosted-service/subgraph/gitcoinco/grants-hub-goerli-testnet   | https://api.thegraph.com/subgraphs/name/gitcoinco/grants-hub-goerli-testnet   |
+| fantom         | gitcoinco/grants-hub-fantom-mainnet   | https://thegraph.com/hosted-service/subgraph/gitcoinco/grants-hub-fantom-mainnet   | https://api.thegraph.com/subgraphs/name/gitcoinco/grants-hub-fantom-mainnet   |
+| fantom-testnet | gitcoinco/grants-hub-fantom-testnet   | https://thegraph.com/hosted-service/subgraph/gitcoinco/grants-hub-fantom-testnet   | https://api.thegraph.com/subgraphs/name/gitcoinco/grants-hub-fantom-testnet   |
 
 ## Directory Structure
 
@@ -63,7 +62,6 @@ yarn prepare:<NETWORK_TO_DEPLOY_SUBGRAPH>
 | -------------- |
 | optimism       |
 | goerli         |
-| optimism-kovan |
 | fantom         |
 | fantom-testnet |
 

--- a/graph/config/optimism-kovan.json
+++ b/graph/config/optimism-kovan.json
@@ -1,5 +1,0 @@
-{
-  "network": "optimism-kovan",
-  "startBlock": 4779412,
-  "projectRegistryAddress": "0x95936606EDDB0ccDdD46d05AAB38F210FEEb5A8a"
-}


### PR DESCRIPTION
What it says on the tin.

Only visible thing here is going to be my updates to the readme file...

I also deleted the json file for Optimistic Kovan since that network has been deprecated.