### PR TITLE
613 add mainnet deployment of project registry

### DIFF
--- a/client/src/contracts/deployments.ts
+++ b/client/src/contracts/deployments.ts
@@ -2,9 +2,10 @@ export const chains: { [key: number]: string } = {
   31337: "localhost",
   5: "goerli",
   10: "optimism",
-  69: "optimisticKovan",
+  69: "optimisticKovan", // todo: update to 420: "optimisticGoerli"
   4002: "fantomTestnet",
   250: "fantom",
+  1: "mainnet",
 };
 
 export const addresses: { [key: string]: any } = {
@@ -13,6 +14,9 @@ export const addresses: { [key: string]: any } = {
   },
   optimism: {
     projectRegistry: "0x8e1bD5Da87C14dd8e08F7ecc2aBf9D1d558ea174",
+  },
+  mainnet: {
+    projectRegistry: "0x03506eD3f57892C85DB20C36846e9c808aFe9ef4",
   },
   goerli: {
     projectRegistry: "0x832c5391dc7931312CbdBc1046669c9c3A4A28d5",

--- a/client/src/utils/wagmi.ts
+++ b/client/src/utils/wagmi.ts
@@ -63,13 +63,14 @@ if (process.env.REACT_APP_LOCALCHAIN) {
 }
 
 if (process.env.REACT_APP_ENV === "production") {
-  chainsAvailable.push(fantomMainnet, chain.optimism);
+  chainsAvailable.push(chain.mainnet, fantomMainnet, chain.optimism);
 } else {
   chainsAvailable.push(
     chain.optimism,
     chain.goerli,
     fantomTestnet,
-    fantomMainnet
+    fantomMainnet,
+    chain.mainnet
   );
 }
 


### PR DESCRIPTION
Add Ethereum mainnet deployment of ProjectRegistry contract and add to list of available networks.

![Screenshot 2022-11-28 at 6 06 37 PM](https://user-images.githubusercontent.com/9419140/204399686-1b7b1951-f1e7-472e-b2a9-6a2d11fbd941.png)
