### PR TITLE
env var added to choose hardware wallet

### DIFF
--- a/contracts/.env.example
+++ b/contracts/.env.example
@@ -10,3 +10,4 @@ OPTIMISTIC_KOVAN_URL=https://kovan.optimism.io
 FANTOM_URL=https://rpc.ankr.com/fantom/
 FANTOM_TESTNEST_URL=https://rpc.testnet.fantom.network/
 FANTOM_SCAN_KEY=ABC123ABC123ABC123ABC123ABC123ABC1
+USE_HARDWARE_WALLET=false

--- a/contracts/scripts/migrations/001-deploy-project-registry.ts
+++ b/contracts/scripts/migrations/001-deploy-project-registry.ts
@@ -8,7 +8,7 @@ async function main() {
   let account;
   let accountAddress;
 
-  if(process.env.USE_HARDWARE_WALLET==='true') {
+  if(process.env.USE_HARDWARE_WALLET==="true") {
     // with hardware wallet
     console.log("Waiting for hardware wallet to connect...");
     account = new LedgerSigner(ethers.provider);

--- a/contracts/scripts/migrations/001-deploy-project-registry.ts
+++ b/contracts/scripts/migrations/001-deploy-project-registry.ts
@@ -5,15 +5,19 @@ import { LedgerSigner } from "@anders-t/ethers-ledger";
 async function main() {
   const network = await ethers.provider.getNetwork();
   const networkName = await hre.network.name;
+  let account;
+  let accountAddress;
 
-  // without hardware wallet
-  // const [account] = await ethers.getSigners();
-  // const accountAddress = account.address;
+  if(process.env.USE_HARDWARE_WALLET==='true') {
+    // with hardware wallet
+    console.log("Waiting for hardware wallet to connect...");
+    account = new LedgerSigner(ethers.provider);
+  } else {
+    // default without hardware wallet
+    account = (await ethers.getSigners())[0];
+  }
 
-  // with hardware wallet
-  const account = new LedgerSigner(ethers.provider);
-  const accountAddress = await account.getAddress();
-
+  accountAddress = await account.getAddress();
   const balance = await ethers.provider.getBalance(accountAddress);
 
   console.log(`chainId: ${network.chainId}`);

--- a/contracts/scripts/migrations/002-upgrade-project-registry.ts
+++ b/contracts/scripts/migrations/002-upgrade-project-registry.ts
@@ -10,7 +10,7 @@ async function main() {
   let account;
   let accountAddress;
 
-  if(process.env.USE_HARDWARE_WALLET==='true') {
+  if(process.env.USE_HARDWARE_WALLET==="true") {
     // with hardware wallet
     console.log("Waiting for hardware wallet to connect...");
     account = new LedgerSigner(ethers.provider);

--- a/contracts/scripts/migrations/002-upgrade-project-registry.ts
+++ b/contracts/scripts/migrations/002-upgrade-project-registry.ts
@@ -1,3 +1,4 @@
+import { LedgerSigner } from "@anders-t/ethers-ledger";
 import hre, { ethers, upgrades } from "hardhat";
 import { prompt, prettyNum } from "../../lib/utils";
 
@@ -6,8 +7,20 @@ const PROXY_ADDRESS = undefined;
 async function main() {
   const network = await ethers.provider.getNetwork();
   const networkName = await hre.network.name;
-  const [account] = await ethers.getSigners();
-  const balance = await ethers.provider.getBalance(account.address);
+  let account;
+  let accountAddress;
+
+  if(process.env.USE_HARDWARE_WALLET==='true') {
+    // with hardware wallet
+    console.log("Waiting for hardware wallet to connect...");
+    account = new LedgerSigner(ethers.provider);
+  } else {
+    // default without hardware wallet
+    account = (await ethers.getSigners())[0];
+  }
+  accountAddress = await account.getAddress();
+
+  const balance = await ethers.provider.getBalance(accountAddress);
 
   if (PROXY_ADDRESS === undefined) {
     console.error("set the PROXY_ADDRESS variable");
@@ -16,14 +29,14 @@ async function main() {
 
   console.log(`chainId: ${network.chainId}`);
   console.log(`network: ${networkName} (from ethers: ${network.name})`);
-  console.log(`account: ${account.address}`);
+  console.log(`account: ${accountAddress}`);
   console.log(`balance: ${prettyNum(balance.toString())}`);
   console.log(`proxy address: ${PROXY_ADDRESS}`);
 
   await prompt("do you want to upgrade the ProjectRegistry contract to V2?");
   console.log("deploying...");
 
-  const ProjectRegistryV2 = await ethers.getContractFactory("ProjectRegistryV2");
+  const ProjectRegistryV2 = await ethers.getContractFactory("ProjectRegistryV2", account);
   const upgraded = await upgrades.upgradeProxy(PROXY_ADDRESS, ProjectRegistryV2);
   console.log("tx hash", upgraded.deployTransaction.hash);
   await upgraded.deployed();


### PR DESCRIPTION
While I was looking into the repo, I was initially unable to run the deployment script. It turned out that it was waiting for response from a hardware wallet. 

This change introduces an env variable to be set when a hardware wallet is used for the deployment.