### PR TITLE
[PM-UX Review][522] Switch network on project edit

### DIFF
--- a/client/src/__tests__/components/rounds/Show.test.tsx
+++ b/client/src/__tests__/components/rounds/Show.test.tsx
@@ -58,14 +58,14 @@ describe("<Show />", () => {
         renderWrapped(<Show />, store);
 
         const element = screen.getByTestId("switch-networks-modal-button");
-        const button = element.firstChild;
+        const button = element.children[1];
 
-        expect(button).toHaveTextContent("Switch Networks to Continue");
+        expect(button).toHaveTextContent("Switch Network");
 
         expect(screen.getByTestId("switch-networks-modal")).toBeInTheDocument();
         expect(
           screen.getByTestId("switch-networks-modal-title")
-        ).toHaveTextContent("Switch Networks to Continue");
+        ).toHaveTextContent("Switch Network");
       });
 
       test("does not render when the round's chainId matches the user's chainId", async () => {

--- a/client/src/components/base/SwitchNetworkModal.tsx
+++ b/client/src/components/base/SwitchNetworkModal.tsx
@@ -4,9 +4,11 @@ import Button, { ButtonVariants } from "./Button";
 function SwitchNetworkModal({
   networkName,
   onSwitchNetwork,
+  action,
 }: {
   networkName: string;
   onSwitchNetwork: () => void;
+  action?: string;
 }) {
   return (
     <BaseModal isOpen onClose={() => {}} hideCloseButton>
@@ -18,8 +20,8 @@ function SwitchNetworkModal({
                 Switch Networks to Continue
               </p>
               <p className="text-gitcoin-grey-400 text-[16px] flex justify-center p-2">
-                To apply for this round on {networkName}, you need to switch the
-                network on your wallet.
+                To {action || "apply for this round"} on {networkName}, you need
+                to switch the network on your wallet.
               </p>
             </div>
           </div>

--- a/client/src/components/base/SwitchNetworkModal.tsx
+++ b/client/src/components/base/SwitchNetworkModal.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from "react-router-dom";
 import { BaseModal } from "./BaseModal";
 import Button, { ButtonVariants } from "./Button";
 
@@ -8,8 +9,11 @@ function SwitchNetworkModal({
 }: {
   networkName: string;
   onSwitchNetwork: () => void;
+  toggleModal: (status: boolean) => void;
   action?: string;
 }) {
+  const navigate = useNavigate();
+
   return (
     <BaseModal isOpen onClose={() => {}} hideCloseButton>
       <>
@@ -28,14 +32,23 @@ function SwitchNetworkModal({
         </div>
         <div
           data-testid="switch-networks-modal-button"
-          className="w-full justify-center text-center grid grid-cols-1"
+          className="w-full justify-center text-center grid grid-cols-2 gap-3"
         >
+          <Button
+            variant={ButtonVariants.outline}
+            onClick={() => navigate(-1)}
+            styles={["cancel-button"]}
+          >
+            <span className="inline-flex flex-1 justify-center items-center">
+              Cancel
+            </span>
+          </Button>
           <Button
             styles={["p-3", "justify-center"]}
             onClick={onSwitchNetwork}
             variant={ButtonVariants.primary}
           >
-            Switch Networks to Continue
+            Switch Network
           </Button>
         </div>
       </>

--- a/client/src/components/base/SwitchNetworkModal.tsx
+++ b/client/src/components/base/SwitchNetworkModal.tsx
@@ -9,7 +9,6 @@ function SwitchNetworkModal({
 }: {
   networkName: string;
   onSwitchNetwork: () => void;
-  toggleModal: (status: boolean) => void;
   action?: string;
 }) {
   const navigate = useNavigate();


### PR DESCRIPTION
Closes #522 

<img width="1309" alt="Screenshot 2022-12-14 alle 19 20 40" src="https://user-images.githubusercontent.com/129965/207743421-34e9e91d-a8d2-43a7-aeb0-9d222c1f3c6f.png">

The SwitchNetwork modal is not really generic, I modified it to support a customisable message but we should def refactor it later on.