### PR TITLE
Fix project loading state

### DIFF
--- a/client/src/__tests__/components/grants/List.test.tsx
+++ b/client/src/__tests__/components/grants/List.test.tsx
@@ -73,7 +73,7 @@ describe("<List />", () => {
 
     test("should not be called if it's already loading", async () => {
       const store = setupStore();
-      store.dispatch({ type: "PROJECTS_LOADING" });
+      store.dispatch({ type: "PROJECTS_LOADING", payload: 0 });
 
       renderWrapped(<List />, store);
 
@@ -104,10 +104,13 @@ describe("<List />", () => {
 
       store.dispatch({
         type: "PROJECTS_LOADED",
-        events: {
-          "1:1:1": {
-            createdAtBlock: 1111,
-            updatedAtBlock: 1112,
+        payload: {
+          chainID: 0,
+          events: {
+            "1:1:1": {
+              createdAtBlock: 1111,
+              updatedAtBlock: 1112,
+            },
           },
         },
       });
@@ -134,10 +137,13 @@ describe("<List />", () => {
 
       store.dispatch({
         type: "PROJECTS_LOADED",
-        events: {
-          "1:1:1": {
-            createdAtBlock: 1111,
-            updatedAtBlock: 1112,
+        payload: {
+          chainID: 0,
+          events: {
+            "1:1:1": {
+              createdAtBlock: 1111,
+              updatedAtBlock: 1112,
+            },
           },
         },
       });
@@ -166,10 +172,13 @@ describe("<List />", () => {
 
       store.dispatch({
         type: "PROJECTS_LOADED",
-        events: {
-          "1:1:1": {
-            createdAtBlock: 1111,
-            updatedAtBlock: 1112,
+        payload: {
+          chainID: 0,
+          events: {
+            "1:1:1": {
+              createdAtBlock: 1111,
+              updatedAtBlock: 1112,
+            },
           },
         },
       });
@@ -194,7 +203,10 @@ describe("<List />", () => {
         .calledWith("roundToApply", null)
         .mockReturnValue([null]);
 
-      store.dispatch({ type: "PROJECTS_LOADED", events: {} });
+      store.dispatch({
+        type: "PROJECTS_LOADED",
+        payload: { chainID: 0, events: {} },
+      });
 
       renderWrapped(<List />, store);
 
@@ -206,7 +218,7 @@ describe("<List />", () => {
     describe("projects", () => {
       test("should show a loading element", async () => {
         const store = setupStore();
-        store.dispatch({ type: "PROJECTS_LOADING" });
+        store.dispatch({ type: "PROJECTS_LOADING", payload: 0 });
 
         renderWrapped(<List />, store);
 
@@ -216,7 +228,10 @@ describe("<List />", () => {
 
       test("should show an empty list", async () => {
         const store = setupStore();
-        store.dispatch({ type: "PROJECTS_LOADED", events: {} });
+        store.dispatch({
+          type: "PROJECTS_LOADED",
+          payload: { chainID: 0, events: {} },
+        });
 
         renderWrapped(<List />, store);
 
@@ -230,7 +245,10 @@ describe("<List />", () => {
       test("should show projects", async () => {
         const store = setupStore();
 
-        store.dispatch({ type: "PROJECTS_LOADED", events: projectEventsMap });
+        store.dispatch({
+          type: "PROJECTS_LOADED",
+          payload: { chainID: 0, events: projectEventsMap },
+        });
         store.dispatch({
           type: "GRANT_METADATA_FETCHED",
           data: projectsMetadata[0],
@@ -253,7 +271,10 @@ describe("<List />", () => {
       beforeEach(() => {
         store = setupStore();
 
-        store.dispatch({ type: "PROJECTS_LOADED", events: projectEventsMap });
+        store.dispatch({
+          type: "PROJECTS_LOADED",
+          payload: { chainID: 0, events: projectEventsMap },
+        });
 
         store.dispatch({
           type: "GRANT_METADATA_FETCHED",
@@ -343,7 +364,10 @@ describe("<List />", () => {
       beforeEach(() => {
         store = setupStore();
 
-        store.dispatch({ type: "PROJECTS_LOADED", events: projectEventsMap });
+        store.dispatch({
+          type: "PROJECTS_LOADED",
+          payload: { chainID: 0, events: projectEventsMap },
+        });
 
         store.dispatch({
           type: "GRANT_METADATA_FETCHED",
@@ -372,10 +396,13 @@ describe("<List />", () => {
           store.dispatch({ type: "PROJECTS_UNLOADED" });
           store.dispatch({
             type: "PROJECTS_LOADED",
-            events: {
-              "1:1:1": {
-                createdAtBlock: 1111,
-                updatedAtBlock: 1112,
+            payload: {
+              chainID: 0,
+              events: {
+                "1:1:1": {
+                  createdAtBlock: 1111,
+                  updatedAtBlock: 1112,
+                },
               },
             },
           });

--- a/client/src/__tests__/components/rounds/Show.test.tsx
+++ b/client/src/__tests__/components/rounds/Show.test.tsx
@@ -96,7 +96,7 @@ describe("<Show />", () => {
         (loadRound as jest.Mock).mockReturnValue({ type: "TEST" });
         (unloadRounds as jest.Mock).mockReturnValue({ type: "TEST" });
 
-        store.dispatch({ type: "PROJECTS_LOADING" });
+        store.dispatch({ type: "PROJECTS_LOADING", payload: 0 });
 
         renderWrapped(<Show />, store);
 
@@ -119,7 +119,10 @@ describe("<Show />", () => {
 
         store.dispatch({
           type: "PROJECTS_LOADED",
-          events: {},
+          payload: {
+            chainID: 0,
+            events: {},
+          },
         });
 
         renderWrapped(<Show />, store);
@@ -134,7 +137,10 @@ describe("<Show />", () => {
 
         store.dispatch({
           type: "PROJECTS_LOADED",
-          events: {},
+          payload: {
+            chainID: 0,
+            events: {},
+          },
         });
 
         renderWrapped(<Show />, store);

--- a/client/src/__tests__/reducers/projects.test.ts
+++ b/client/src/__tests__/reducers/projects.test.ts
@@ -13,6 +13,7 @@ describe("projects reducer", () => {
   beforeEach(() => {
     state = {
       status: Status.Undefined,
+      loadingChains: [],
       error: undefined,
       ids: [],
       events: {},
@@ -144,5 +145,45 @@ describe("projects reducer", () => {
       ],
       "3": [{ roundID: "0x3", status: "PENDING" as AppStatus, chainId: 1 }],
     });
+  });
+
+  it("handles multiple chain loading statuses", async () => {
+    const state1: ProjectsState = projectsReducer(state, {
+      type: "PROJECTS_LOADING",
+      payload: 0,
+    });
+
+    expect(state1.status).toEqual(Status.Loading);
+    expect(state1.loadingChains.length).toEqual(1);
+
+    const state2: ProjectsState = projectsReducer(state1, {
+      type: "PROJECTS_LOADING",
+      payload: 1,
+    });
+
+    expect(state2.status).toEqual(Status.Loading);
+    expect(state2.loadingChains.length).toEqual(2);
+
+    const state3: ProjectsState = projectsReducer(state2, {
+      type: "PROJECTS_LOADED",
+      payload: {
+        chainID: 1,
+        events: {},
+      },
+    });
+
+    expect(state3.status).toEqual(Status.Loading);
+    expect(state3.loadingChains.length).toEqual(1);
+
+    const state4: ProjectsState = projectsReducer(state3, {
+      type: "PROJECTS_LOADED",
+      payload: {
+        chainID: 0,
+        events: {},
+      },
+    });
+
+    expect(state4.status).toEqual(Status.Loaded);
+    expect(state4.loadingChains.length).toEqual(0);
   });
 });

--- a/client/src/__tests__/reducers/projects.test.ts
+++ b/client/src/__tests__/reducers/projects.test.ts
@@ -147,7 +147,8 @@ describe("projects reducer", () => {
     });
   });
 
-  it("handles multiple chain loading statuses", async () => {
+  it("handles multiple chain loading states", async () => {
+    // start loading chain 0
     const state1: ProjectsState = projectsReducer(state, {
       type: "PROJECTS_LOADING",
       payload: 0,
@@ -156,6 +157,7 @@ describe("projects reducer", () => {
     expect(state1.status).toEqual(Status.Loading);
     expect(state1.loadingChains.length).toEqual(1);
 
+    // start loading chain 1
     const state2: ProjectsState = projectsReducer(state1, {
       type: "PROJECTS_LOADING",
       payload: 1,
@@ -164,6 +166,7 @@ describe("projects reducer", () => {
     expect(state2.status).toEqual(Status.Loading);
     expect(state2.loadingChains.length).toEqual(2);
 
+    // mark chain 1 as done
     const state3: ProjectsState = projectsReducer(state2, {
       type: "PROJECTS_LOADED",
       payload: {
@@ -175,6 +178,7 @@ describe("projects reducer", () => {
     expect(state3.status).toEqual(Status.Loading);
     expect(state3.loadingChains.length).toEqual(1);
 
+    // mark chain 0 as done
     const state4: ProjectsState = projectsReducer(state3, {
       type: "PROJECTS_LOADED",
       payload: {

--- a/client/src/actions/projects.ts
+++ b/client/src/actions/projects.ts
@@ -17,13 +17,17 @@ import { fetchGrantData } from "./grantsMetadata";
 
 export const PROJECTS_LOADING = "PROJECTS_LOADING";
 interface ProjectsLoadingAction {
+  payload: number;
   type: typeof PROJECTS_LOADING;
 }
 
 export const PROJECTS_LOADED = "PROJECTS_LOADED";
 interface ProjectsLoadedAction {
   type: typeof PROJECTS_LOADED;
-  events: ProjectEventsMap;
+  payload: {
+    chainID: number;
+    events: ProjectEventsMap;
+  };
 }
 
 export const PROJECTS_ERROR = "PROJECTS_ERROR";
@@ -75,13 +79,20 @@ export type ProjectsActions =
   | ProjectApplicationsErrorAction
   | ProjectApplicationUpdatedAction;
 
-const projectsLoading = () => ({
+export const projectsLoading = (chainID: number): ProjectsLoadingAction => ({
   type: PROJECTS_LOADING,
+  payload: chainID,
 });
 
-const projectsLoaded = (events: ProjectEventsMap) => ({
+export const projectsLoaded = (
+  chainID: number,
+  events: ProjectEventsMap
+): ProjectsLoadedAction => ({
   type: PROJECTS_LOADED,
-  events,
+  payload: {
+    chainID,
+    events,
+  },
 });
 
 const projectsUnload = () => ({
@@ -240,7 +251,7 @@ export const loadProjects =
     if (project.ids.length === 0) {
       // No projects found for this address on this chain
       // This is not necessarily an error now that we fetch on all chains
-      dispatch(projectsLoaded({}));
+      dispatch(projectsLoaded(chainID, {}));
       return;
     }
 
@@ -255,14 +266,14 @@ export const loadProjects =
         dispatch<any>(fetchGrantData(id));
       });
     }
-    dispatch(projectsLoaded(projectEventsMap));
+    dispatch(projectsLoaded(chainID, projectEventsMap));
   };
 
 export const loadAllChainsProjects =
   (withMetaData?: boolean) => async (dispatch: Dispatch) => {
-    dispatch(projectsLoading());
     const { web3Provider } = global;
     web3Provider?.chains?.forEach((chainID) => {
+      dispatch(projectsLoading(chainID.id));
       dispatch<any>(loadProjects(chainID.id, withMetaData));
     });
   };

--- a/client/src/reducers/projects.ts
+++ b/client/src/reducers/projects.ts
@@ -33,6 +33,7 @@ export type Application = {
 
 export interface ProjectsState {
   status: Status;
+  loadingChains: number[];
   error: string | undefined;
   ids: string[];
   events: ProjectEventsMap;
@@ -43,6 +44,7 @@ export interface ProjectsState {
 
 const initialState: ProjectsState = {
   status: Status.Undefined,
+  loadingChains: [],
   error: undefined,
   ids: [],
   events: {},
@@ -58,19 +60,22 @@ export const projectsReducer = (
       return {
         ...state,
         status: Status.Loading,
+        loadingChains: [...state.loadingChains, action.payload],
         ids: [],
       };
     }
 
     case PROJECTS_LOADED: {
-      const { events } = action;
+      const { chainID, events } = action.payload;
       const ids = Object.keys(events);
+      const loadingChains = state.loadingChains.filter((id) => id !== chainID);
 
       return {
         ...state,
-        status: Status.Loaded,
+        status: loadingChains.length === 0 ? Status.Loaded : state.status,
         ids: [...state.ids, ...ids],
         events: { ...state.events, ...events },
+        loadingChains,
       };
     }
 


### PR DESCRIPTION
This fixes #688 

The fix keeps track of the different loading states of each chain / network to know when it's really done.

While working on this I identified some things I wanted to comment on:

- I believe it would make future refactorings easier if we used action creators in the test, we might have to change how the mocks are done to accomplish this because they're auto-mocked by Jest at the moment
- It doesn't seem like we're handling errors when loading projects, unless I've missed it!
- The error shown at the moment errors for the whole page, it could happen that only a single network errors, we should find a way to show this in the UI