### PR TITLE
Hotfix: patch loading applications

### DIFF
--- a/client/src/actions/projects.ts
+++ b/client/src/actions/projects.ts
@@ -339,10 +339,16 @@ export const fetchProjectApplications =
         addresses.projectRegistry
       );
 
+      const projectApplicationIDWithChain = generateUniqueRoundApplicationID(
+        chain.id,
+        projectID,
+        addresses.projectRegistry
+      );
+
       try {
         const response: any = await graphqlFetch(
-          `query roundProjects($projectID: String) {
-            roundProjects(where: { project: $projectID }) {
+          `query roundProjects($projectID: String, $projectApplicationIDWithChain: String) {
+            roundProjects(where: { project_in: [$projectID, $projectApplicationIDWithChain] }) {
               status
               round {
                 id
@@ -351,7 +357,10 @@ export const fetchProjectApplications =
           }
           `,
           chain.id,
-          { projectID: projectApplicationID },
+          {
+            projectID: projectApplicationID,
+            projectApplicationIDWithChain,
+          },
           reactEnv
         );
 

--- a/client/src/actions/projects.ts
+++ b/client/src/actions/projects.ts
@@ -339,6 +339,10 @@ export const fetchProjectApplications =
         addresses.projectRegistry
       );
 
+      // During the first alpha round, we created applications with the wrong chain id (using the
+      // round chain instead of the project chain). This is a fix to display the applications with
+      // the wrong application id. NOTE: there is a possibility of clash, because the contracts
+      // have the same address on multiple chains.
       const projectApplicationIDWithChain = generateUniqueRoundApplicationID(
         chain.id,
         projectID,

--- a/client/src/utils/graphql.ts
+++ b/client/src/utils/graphql.ts
@@ -31,7 +31,7 @@ const getGraphQLEndpoint = (
     case ChainId.MAINNET_CHAIN_ID:
       return {
         // eslint-disable-next-line max-len
-        uri: `https://gateway.thegraph.com/api/${environment.REACT_APP_SUBGRAPH_MAINNET_API_KEY}/subgraphs/id/94TgNF87pKDcuhFkELKQa6o3CcetJvyt3XwkhtsvhrHx`,
+        uri: `https://gateway.thegraph.com/api/${environment.REACT_APP_SUBGRAPH_MAINNET_API_KEY}/subgraphs/id/BQXTJRLZi7NWGq5AXzQQxvYNa5i1HmqALEJwy3gGJHCr`,
         error: undefined,
       };
     case ChainId.GOERLI_CHAIN_ID:


### PR DESCRIPTION
During the first alpha round we created applications with the wrong chain id (using the round chain instead of the project chain). This is a fix to display the applications with the wrong application id. 

**NOTE:** there is a possibility of clash, because the contracts have the same address on multiple chains.