### PR TITLE
Handle errors when loading projects

### DIFF
--- a/client/jest.config.js
+++ b/client/jest.config.js
@@ -1,8 +1,12 @@
 /** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
 module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'jsdom',
+  preset: "ts-jest/presets/js-with-ts",
+  testEnvironment: "jsdom",
   clearMocks: true,
   resetMocks: true,
   coverageProvider: "v8",
+  verbose: true,
+  // @rainbow-me/rainbowkit is already an ESM module and
+  // it trips Jest when it tries to transform it, this ignores it
+  transformIgnorePatterns: ["node_modules\\/(?!@rainbow-me\\/.*)"],
 };


### PR DESCRIPTION
resolves #716 

Loading projects sometimes can fail for one chain but work for another, at the moment the project list page just loads forever, this handles errors, showing a little alert instructing the user to refresh. Projects loaded from other chains will still be shown even if an error happens.

<img width="755" alt="Screenshot 2023-01-17 at 10 27 09" src="https://user-images.githubusercontent.com/711886/212861141-11ece38f-834b-4d7f-8798-23aa49132442.png">
