### PR TITLE
Ensure target=_blank doesn't get exploited

### DIFF
--- a/client/src/utils/markdown.ts
+++ b/client/src/utils/markdown.ts
@@ -21,7 +21,7 @@ markdownIt.renderer.rules.link_open = function linkOpen(
   self
 ) {
   tokens[idx].attrPush(["target", "_blank"]);
-  tokens[idx].attrPush(["rel", "nofollow"]);
+  tokens[idx].attrPush(["rel", "nofollow noopener noreferrer"]);
   return defaultLinkOpen(tokens, idx, options, env, self);
 };
 


### PR DESCRIPTION
The DOMPurify library seems to remove the `target` attribute in anchors by default, I thought there might be a good reason for it so I found out that you could use that attribute to inject some scripts: https://security.stackexchange.com/questions/216135/xss-with-a-tag-with-target-blank
